### PR TITLE
Add the support of Libmetal and Open-amp upstream as Zephyr module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(libmetal)
+add_subdirectory(open-amp)

--- a/libmetal/CMakeLists.txt
+++ b/libmetal/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2018 Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if(CONFIG_LIBMETAL)
+set(WITH_ZEPHYR 1)
+set(WITH_ZEPHYR_LIB 1)
+set(WITH_DOC OFF CACHE BOOL "" FORCE)
+set(WITH_DEFAULT_LOGGER OFF CACHE BOOL "" FORCE)
+
+add_subdirectory(${ZEPHYR_BASE}/../libmetal libmetal)
+endif()

--- a/libmetal/README
+++ b/libmetal/README
@@ -1,0 +1,6 @@
+OpenAMP Libmetal Zephyr Module Support
+######################################
+
+Zephyr module support to use upstream libmetal with zephyr.
+
+libmetal URL: https://github.com/OpenAMP/libmetal

--- a/open-amp/CMakeLists.txt
+++ b/open-amp/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2018 Linaro Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if(CONFIG_OPENAMP)
+set(WITH_ZEPHYR 1)
+set(WITH_ZEPHYR_LIB 1)
+if (CONFIG_OPENAMP_MASTER)
+  set(WITH_VIRTIO_DRIVER 1)
+else()
+  set(WITH_VIRTIO_DRIVER OFF CACHE BOOL "" FORCE)
+endif()
+if (CONFIG_OPENAMP_SLAVE)
+  set(WITH_VIRTIO_DEVICE 1)
+else()
+  set(WITH_VIRTIO_DEVICE OFF CACHE BOOL "" FORCE)
+endif()
+if (CONFIG_OPENAMP_WITH_DCACHE)
+  set(WITH_DCACHE_VRINGS 1)
+  set(WITH_DCACHE_BUFFERS 1)
+endif()
+set(WITH_LIBMETAL_FIND OFF CACHE BOOL "" FORCE)
+set(WITH_PROXY OFF CACHE BOOL "" FORCE)
+
+add_subdirectory(${ZEPHYR_BASE}/../open-amp open-amp)
+
+endif()

--- a/open-amp/README
+++ b/open-amp/README
@@ -1,0 +1,6 @@
+open-amp library Zephyr Module Support
+######################################
+
+Zephyr module support to use upstream open-amp with zephyr.
+
+open-amp URL: https://github.com/OpenAMP/open-amp

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,2 @@
+build:
+  cmake: .


### PR DESCRIPTION
Instead of using the zephyr modules, create new ones to be able to point to the upstream versions of open-amp and libmetal libraries