### PR TITLE
Add ZEPHYR_MODULE handling for open-amp and libmetal

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,7 @@
+config ZEPHYR_LIBMETAL_MODULE
+    bool
+    default y
+
+config ZEPHYR_OPEN_AMP_MODULE
+    bool
+    default y


### PR DESCRIPTION
Zephyr >= 3.6 generates Kconfig entries like ZEPHYR_<mod_name>_MODULE (e.g. ZEPHYR_OPEN_AMP_MODULE) which are dependencies for including <mod_name> in the build.

This commit adds a Kconfig file to provide defaults for OPEN_AMP and LIBMETAL.